### PR TITLE
Update main with some shell bug fixes.

### DIFF
--- a/SrcMod/Shell/Modules/BaseModule.cs
+++ b/SrcMod/Shell/Modules/BaseModule.cs
@@ -100,9 +100,6 @@ public static class BaseModule
         });
     }
 
-    [Command("cut")]
-    public static void CutFile(string source, string destination) => MoveFile(source, destination);
-
     [Command("del")]
     public static void Delete(string path)
     {
@@ -189,9 +186,6 @@ public static class BaseModule
     [Command("echo")]
     public static void Echo(string msg) => Write(msg);
 
-    [Command("exit")]
-    public static void ExitShell(int code = 0) => QuitShell(code);
-
     [Command("explorer")]
     public static void OpenExplorer(string path = ".") => Process.Start("explorer.exe", Path.GetFullPath(path));
 
@@ -210,6 +204,7 @@ public static class BaseModule
         DisplayWithPages(lines);
     }
 
+    [Command("cut")]
     [Command("move")]
     public static void MoveFile(string source, string destination)
     {
@@ -287,6 +282,7 @@ public static class BaseModule
     }
 
     [Command("print")]
+    [Command("type")]
     public static void Print(string file)
     {
         if (!File.Exists(file)) throw new($"No file exists at \"{file}\"");
@@ -346,14 +342,12 @@ public static class BaseModule
         });
     }
 
+    [Command("exit")]
     [Command("quit")]
     public static void QuitShell(int code = 0)
     {
         Environment.Exit(code);
     }
-
-    [Command("type")]
-    public static void Type(string file) => Print(file);
 
     [Command("undo")]
     public static void UndoCommand(int amount = 1)

--- a/SrcMod/Shell/Modules/BaseModule.cs
+++ b/SrcMod/Shell/Modules/BaseModule.cs
@@ -342,6 +342,21 @@ public static class BaseModule
         });
     }
 
+    [Command("testing")]
+    public static void Testing()
+    {
+        LoadingBarStart();
+        int count = 0;
+        for (float f = 0; f <= 1; f += 0.01f)
+        {
+            LoadingBarSet(f);
+            count++;
+            if (count % 10 == 0) Write("wowie!");
+            Thread.Sleep(15);
+        }
+        LoadingBarEnd();
+    }
+
     [Command("exit")]
     [Command("quit")]
     public static void QuitShell(int code = 0)

--- a/SrcMod/Shell/Modules/BaseModule.cs
+++ b/SrcMod/Shell/Modules/BaseModule.cs
@@ -342,21 +342,6 @@ public static class BaseModule
         });
     }
 
-    [Command("testing")]
-    public static void Testing()
-    {
-        LoadingBarStart();
-        int count = 0;
-        for (float f = 0; f <= 1; f += 0.01f)
-        {
-            LoadingBarSet(f);
-            count++;
-            if (count % 10 == 0) Write("wowie!");
-            Thread.Sleep(15);
-        }
-        LoadingBarEnd();
-    }
-
     [Command("exit")]
     [Command("quit")]
     public static void QuitShell(int code = 0)

--- a/SrcMod/Shell/Modules/ObjectModels/CommandAttribute.cs
+++ b/SrcMod/Shell/Modules/ObjectModels/CommandAttribute.cs
@@ -1,6 +1,6 @@
 ﻿namespace SrcMod.Shell.Modules.ObjectModels;
 
-[AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+[AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
 public class CommandAttribute : Attribute
 {
     public readonly string NameId;

--- a/SrcMod/Shell/Modules/ObjectModels/ModuleInfo.cs
+++ b/SrcMod/Shell/Modules/ObjectModels/ModuleInfo.cs
@@ -18,7 +18,7 @@ public class ModuleInfo
         NameIsPrefix = true;
     }
 
-    public static ModuleInfo? FromModule(Type info)
+    public static ModuleInfo? FromType(Type info)
     {
         ModuleAttribute? attribute = info.GetCustomAttribute<ModuleAttribute>();
         if (attribute is null) return null;
@@ -37,9 +37,9 @@ public class ModuleInfo
         List<CommandInfo> commands = new();
         foreach (MethodInfo method in info.GetMethods())
         {
-            CommandInfo? cmd = CommandInfo.FromMethod(module, method);
-            if (cmd is null) continue;
-            commands.Add(cmd);
+            CommandInfo[] cmds = CommandInfo.FromMethod(module, method);
+            if (cmds.Length <= 0) continue;
+            commands.AddRange(cmds);
         }
 
         module.Commands.AddRange(commands);

--- a/SrcMod/Shell/Shell.cs
+++ b/SrcMod/Shell/Shell.cs
@@ -4,7 +4,7 @@ public class Shell
 {
     public const string Author = "That_One_Nerd";
     public const string Name = "SrcMod";
-    public const string Version = "Alpha 0.2.1";
+    public const string Version = "Alpha 0.2.2";
 
     public readonly string? ShellDirectory;
 

--- a/SrcMod/Shell/Shell.cs
+++ b/SrcMod/Shell/Shell.cs
@@ -4,7 +4,7 @@ public class Shell
 {
     public const string Author = "That_One_Nerd";
     public const string Name = "SrcMod";
-    public const string Version = "Alpha 0.1.0";
+    public const string Version = "Alpha 0.2.1";
 
     public readonly string? ShellDirectory;
 
@@ -62,7 +62,7 @@ public class Shell
         }
         foreach (Type t in possibleModules)
         {
-            ModuleInfo? module = ModuleInfo.FromModule(t);
+            ModuleInfo? module = ModuleInfo.FromType(t);
             if (module is not null)
             {
                 LoadedModules.Add(module);

--- a/SrcMod/Shell/Tools.cs
+++ b/SrcMod/Shell/Tools.cs
@@ -7,6 +7,8 @@ public static class Tools
     private static int loadingPosition = -1;
     private static int lastLoadingBufferSize = 0;
     private static int lastLoadingValue = -1;
+    private static float loadingBarValue = 0;
+    private static ConsoleColor loadingBarColor = Console.ForegroundColor;
 
     public static bool LoadingBarEnabled { get; private set; }
 
@@ -101,6 +103,9 @@ public static class Tools
 
         Int2 oldPos = (Console.CursorLeft, Console.CursorTop);
 
+        loadingBarValue = value;
+        loadingBarColor = color ?? Console.ForegroundColor;
+
         // Erase last bar.
         Console.SetCursorPosition(0, loadingPosition);
         Console.Write(new string(' ', lastLoadingBufferSize));
@@ -119,14 +124,20 @@ public static class Tools
         Write(right, newLine: false);
 
         if (oldPos.y == Console.CursorTop) oldPos.y++;
+        while (oldPos.y >= Console.BufferHeight)
+        {
+            Console.WriteLine();
+            oldPos.y--;
+            loadingPosition--;
+        }
         Console.SetCursorPosition(oldPos.x, oldPos.y);
     }
     public static void LoadingBarStart(float value = 0, int? position = null, ConsoleColor? color = null)
     {
         if (loadingPosition != -1) throw new("The loading bar has already been enabled.");
         loadingPosition = position ?? Console.CursorTop;
-        LoadingBarSet(value, color);
         LoadingBarEnabled = true;
+        LoadingBarSet(value, color);
     }
 
     public static void Write(object? message, ConsoleColor? col = null, bool newLine = true)
@@ -138,6 +149,12 @@ public static class Tools
         else Console.Write(message);
 
         Console.ForegroundColor = prevCol;
+
+        if (newLine && LoadingBarEnabled && Console.CursorTop >= Console.BufferHeight - 1)
+        {
+            loadingPosition--;
+            LoadingBarSet(loadingBarValue, loadingBarColor);
+        }
     }
 
     public static bool ValidateUnsafe()


### PR DESCRIPTION
Here's the changelog for this branch:

### Changelog
- Allowed the `CommandAttribute` attribute to be applied to a method multiple times (#18).
- Made `CommandInfo.MethodInfo(ModuleInfo, MethodInfo)` compensate for possible command aliases and return an array of commands rather than just one (#18).
- Renamed the `ModuleInfo.FromModule(Type)` method to `ModuleInfo.FromType(Type)` (#18).
- Merged the `print` and `type` commands into one method (using aliases) (#18).
- Merged the `quit` and `type` commands into one method (using aliases) (#18).
- Merged the `cut` and `move` commands into one method (using aliases) (#18).
- The loading bar now properly closes during a startup error (#19).
- The loading bar no longer throws an error when triggered at the bottom of the console buffer (#19).
- The loading bar no longer duplicates itself when writing additional text that scrolls the screen (#19).